### PR TITLE
Disables pointer events on overlay.

### DIFF
--- a/tool.css
+++ b/tool.css
@@ -5,6 +5,7 @@
 .grow_tool__grid__overlay {
   bottom: 0;
   left: 0;
+  pointer-events: none;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
When the grid is on, it's helpful to click through the grid to view an elements computed styles, etc.  The grid overlay receives focus when you probably don't want to.